### PR TITLE
Fix Compatibility with SDK 3.4.0

### DIFF
--- a/Packages/com.emymin.emychess/package.json
+++ b/Packages/com.emymin.emychess/package.json
@@ -3,14 +3,9 @@
   "displayName": "EmyChess",
   "version": "0.1.2",
   "description": "Udon chess prefab for VRChat",
-  "dependencies": {
-    "com.vrchat.udonsharp": "1.1.6"
-  },
+  "dependencies": {},
   "gitDependencies": {},
-  "vpmDependencies": {
-    "com.vrchat.udonsharp": "1.1.6"
-  },
+  "vpmDependencies": {},
   "legacyFolders": {},
-  "legacyFiles": {},
-  "localPath": "D:\\UnityProjects\\EmyChess_VPM\\Packages\\com.emymin.emychess"
+  "legacyFiles": {}
 }


### PR DESCRIPTION
UdonSharp is now integrated with Worlds SDK 3.4.0, so the dependency has been removed from the package.json. This also fixes an issue where Unity will refuse to open the Project thinking UdonSharp is missing, even though it's already integrated in the Worlds SDK.

For reference, UdonSharp is now located under `./Packages/com.vrchat.worlds/Integrations/UdonSharp`

In addition, localPath was removed due to a bug in the Creator Companion where it will be refused to be resolved.